### PR TITLE
Use ISO language code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ gradle.properties
 # IntelliJ
 *.iml
 /captures
-.idea/caches
+.idea/
 .idea/*.xml
 .idea/libraries
 .idea/markdown-navigator

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.emergetools"
-version = "3.0.0"
+version = "3.1.0"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.emergetools"
-version = "3.1.0"
+version = "3.0.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/net/dongliu/apk/parser/struct/resource/TypeExtensions.kt
+++ b/src/main/java/net/dongliu/apk/parser/struct/resource/TypeExtensions.kt
@@ -11,7 +11,7 @@ fun Type.dirName(): String {
         dirBuilder.append("-mnc${String.format("%03d", this.resTableConfig.mnc)}")
     }
 
-    if (!this.locale.language.isNullOrEmpty()) {
+    if (!this.locale.isO3Language.isNullOrEmpty()) {
         dirBuilder.append("-${this.locale.language}")
     }
     if (!this.locale.country.isNullOrEmpty()) {

--- a/src/main/java/net/dongliu/apk/parser/struct/resource/TypeExtensions.kt
+++ b/src/main/java/net/dongliu/apk/parser/struct/resource/TypeExtensions.kt
@@ -12,7 +12,7 @@ fun Type.dirName(): String {
     }
 
     if (!this.locale.isO3Language.isNullOrEmpty()) {
-        dirBuilder.append("-${this.locale.language}")
+        dirBuilder.append("-${this.locale.isO3Language}")
     }
     if (!this.locale.country.isNullOrEmpty()) {
         dirBuilder.append("-r${this.locale.country}")


### PR DESCRIPTION
Per the [Android qualifier docs](https://developer.android.com/guide/topics/resources/providing-resources), it uses the ISO standard language code for qualifiers for locale/language. This updates to use the iso3language code provided by the locale rather than the language.